### PR TITLE
1.0.4 Added generateKeys

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,30 @@
 # Changes
 
+## Version 1.0.4
+
+### Added
+
+- Added generateKeys method that returns public and private keys
+
+```typescript
+import {Crypto} from '@mhmdhammoud/meritt-utils'
+
+// Example of generating a public and a private key
+const response = Crypto.generateKeys()
+console.log(response)
+
+{
+    publicKey:7,
+    privateKey:247,
+}
+
+
+```
+
+### Fixes and Improvements
+
+- Checking for prime numbers discarding even and odd numbers and skips 6 iterations at a time until radical I
+
 ## Version 1.0.3
 
 ### Added

--- a/dist/lib/cypto.d.ts
+++ b/dist/lib/cypto.d.ts
@@ -1,7 +1,18 @@
 declare class Crypto {
     private _primeNumberP;
     private _primeNumberQ;
+    private _phiN;
     private _moduloDenominator;
+    /**
+     *
+     * @param number - The number to check if prime
+     * @returns The boolean answer of prime checking operation
+     * @example
+     * ```typescript
+     * this._isPrime(5)
+     * ```
+     * */
+    private _isPrime;
     /**
      * Set the P prime number for the RSA algorithm
      * @param primeP - The prime number P of type string
@@ -33,6 +44,36 @@ declare class Crypto {
      * ```
      * */
     private _modularExponentiation;
+    /**
+     *
+     * @param temporaryVarriableOne - The number one
+     * @param temporaryVarriableTwo- The  number two (phi n)
+     * @returns The boolean answer of relatively prime checking operation with phi n
+     * @example
+     * ```typescript
+     * this._areRelativelyPrime(5,9)
+     * ```
+     * */
+    private _areRelativelyPrime;
+    /**
+     *
+     * @returns The public and private key number which is a random number generated to match conditions set by RSA algorithm
+     * @example
+     * ```typescript
+     * crypto.generateKeys()
+     * ```
+     * */
+    generateKeys: () => Record<'publicKey' | 'privateKey', number>;
+    /**
+     *
+     * @param publicKey - The public key number
+     * @returns The private key number which is the modulus inverse with repect to modulo denominator
+     * @example
+     * ```typescript
+     * crypto.generatePrivateKey(5)
+     * ```
+     * */
+    private _generatePrivateKey;
     /**
      * Encrypt the message using the public key
      * @param message - The message to encrypt of type string|number|Record

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mhmdhammoud/meritt-utils",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mhmdhammoud/meritt-utils",
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"license": "ISC",
 			"dependencies": {
 				"dotenv": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mhmdhammoud/meritt-utils",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "",
 	"main": "./dist/index.js",
 	"private": false,

--- a/src/lib/cypto.ts
+++ b/src/lib/cypto.ts
@@ -8,7 +8,40 @@ class Crypto {
 	// Default variables
 	private _primeNumberP = 17
 	private _primeNumberQ = 19
+	private _phiN = (this._primeNumberP - 1) * (this._primeNumberQ - 1)
 	private _moduloDenominator = this._primeNumberP * this._primeNumberQ
+
+	/**
+	 *
+	 * @param number - The number to check if prime
+	 * @returns The boolean answer of prime checking operation
+	 * @example
+	 * ```typescript
+	 * this._isPrime(5)
+	 * ```
+	 * */
+
+	private _isPrime = (number: number): boolean => {
+		if (number <= 1) {
+			return false
+		}
+
+		if (number <= 3) {
+			return true
+		}
+
+		if (number % 2 === 0 || number % 3 === 0) {
+			return false
+		}
+
+		for (let i = 5; i * i <= number; i += 6) {
+			if (number % i === 0 || number % (i + 2) === 0) {
+				return false
+			}
+		}
+
+		return true
+	}
 
 	/**
 	 * Set the P prime number for the RSA algorithm
@@ -19,18 +52,13 @@ class Crypto {
 	 * crypto.setPrimeP(17)
 	 * ```
 	 * */
+
 	public setPrimeP(primeP: number) {
-		if (isNaN(primeP)) {
+		if (isNaN(primeP) || primeP === 0) {
 			throw new Error('Provide a valid number')
 		}
-		let isPrime = true
-		for (let i = 2; i < primeP; i++) {
-			if (primeP % i === 0) {
-				isPrime = false
-				break
-			}
-		}
-		if (!isPrime) {
+
+		if (!this._isPrime(primeP)) {
 			throw new Error('The number is not prime')
 		}
 		this._primeNumberP = primeP
@@ -45,18 +73,12 @@ class Crypto {
 	 * crypto.setPrimeQ(19)
 	 * ```
 	 * */
+
 	public setPrimeQ(primeQ: number) {
-		if (isNaN(primeQ)) {
+		if (isNaN(primeQ) || primeQ === 0) {
 			throw new Error('Provide a valid number')
 		}
-		let isPrime = true
-		for (let i = 2; i < primeQ; i++) {
-			if (primeQ % i === 0) {
-				isPrime = false
-				break
-			}
-		}
-		if (!isPrime) {
+		if (!this._isPrime(primeQ)) {
 			throw new Error('The number is not prime')
 		}
 		this._primeNumberQ = primeQ
@@ -72,6 +94,7 @@ class Crypto {
 	 * this.modularExponentiation(2, 3)
 	 * ```
 	 * */
+
 	private _modularExponentiation = (base: number, exponent: number) => {
 		if (isNaN(base) || isNaN(exponent)) {
 			throw new Error('Provide a valid number')
@@ -92,6 +115,109 @@ class Crypto {
 	}
 
 	/**
+	 *
+	 * @param temporaryVarriableOne - The number one
+	 * @param temporaryVarriableTwo- The  number two (phi n)
+	 * @returns The boolean answer of relatively prime checking operation with phi n
+	 * @example
+	 * ```typescript
+	 * this._areRelativelyPrime(5,9)
+	 * ```
+	 * */
+
+	private _areRelativelyPrime = (
+		temporaryVarriableOne: number,
+		temporaryVarriableTwo: number
+	) => {
+		while (temporaryVarriableTwo !== 0) {
+			const temp = temporaryVarriableTwo
+			temporaryVarriableTwo = temporaryVarriableOne % temporaryVarriableTwo
+			temporaryVarriableOne = temp
+		}
+		return temporaryVarriableOne === 1
+	}
+
+	/**
+	 *
+	 * @returns The public and private key number which is a random number generated to match conditions set by RSA algorithm
+	 * @example
+	 * ```typescript
+	 * crypto.generateKeys()
+	 * ```
+	 * */
+
+	public generateKeys = (): Record<'publicKey' | 'privateKey', number> => {
+		const temporaryArray: number[] = []
+		for (let i = 2; i < this._phiN; i++) {
+			if (this._areRelativelyPrime(i, this._phiN)) {
+				temporaryArray.push(i)
+			}
+		}
+		if (temporaryArray.length === 0)
+			throw new Error('No public key options found!')
+		const randomIndex = Math.floor(Math.random() * temporaryArray.length)
+		// return temporaryArray[randomIndex]
+		const publicKey = temporaryArray[randomIndex]
+		const privateKey = this._generatePrivateKey(publicKey)
+		if (privateKey === publicKey) {
+			return this.generateKeys()
+		}
+		return {
+			privateKey: publicKey,
+			publicKey: privateKey,
+		}
+	}
+
+	/**
+	 *
+	 * @param publicKey - The public key number
+	 * @returns The private key number which is the modulus inverse with repect to modulo denominator
+	 * @example
+	 * ```typescript
+	 * crypto.generatePrivateKey(5)
+	 * ```
+	 * */
+
+	private _generatePrivateKey = (publicKey: number): number => {
+		if (publicKey <= 1 || isNaN(publicKey)) {
+			throw new Error('Public key should be a number greater than 1')
+		}
+
+		if (!this._areRelativelyPrime(publicKey, this._phiN)) {
+			throw new Error(
+				'Public key should be relatively prime with respect to phi N'
+			)
+		}
+
+		let t1 = 0
+		let t2 = 1
+		let r1 = this._phiN
+		let r2 = publicKey
+
+		while (r2 !== 0) {
+			const quotient = Math.floor(r1 / r2)
+			const temp1 = t1
+			const temp2 = r1
+
+			t1 = t2
+			r1 = r2
+
+			t2 = temp1 - quotient * t2
+			r2 = temp2 - quotient * r2
+		}
+
+		if (r1 > 1) {
+			throw new Error('The number does not have a modular inverse.')
+		}
+
+		if (t1 < 0) {
+			t1 += this._phiN
+		}
+
+		return t1
+	}
+
+	/**
 	 * Encrypt the message using the public key
 	 * @param message - The message to encrypt of type string|number|Record
 	 * @param publicKey - The public key to encrypt the message with of type number
@@ -101,12 +227,18 @@ class Crypto {
 	 * crypto.encrypt('Hello World', 7)
 	 * ```
 	 * */
+
 	public encrypt = (
 		message: string | number | Record<any, any>,
 		publicKey: number
 	): number[] => {
 		if (isNaN(publicKey)) {
 			throw new Error('Public key should be a number')
+		}
+		if (publicKey <= 0) {
+			throw new Error(
+				'Private key should be a positive number different than 0'
+			)
 		}
 		if (typeof message === 'number') {
 			message = message.toString()
@@ -134,7 +266,12 @@ class Crypto {
 	 * */
 	public decrypt = (encryptedMessage: number[], privateKey: number): string => {
 		if (isNaN(privateKey)) {
-			throw new Error('Private key should be a number')
+			throw new Error('Public key should be a number')
+		}
+		if (privateKey <= 0) {
+			throw new Error(
+				'Private key should be a positive number different than 0'
+			)
 		}
 		if (!Array.isArray(encryptedMessage)) {
 			throw new Error('Encrypted message should be an array')


### PR DESCRIPTION
## Version 1.0.4

### Added

- Added generateKeys method that returns public and private keys

```typescript
import {Crypto} from '@mhmdhammoud/meritt-utils'

// Example of generating a public and a private key
const response = Crypto.generateKeys()
console.log(response)

{
    publicKey:7,
    privateKey:247,
}


```

### Fixes and Improvements

- Checking for prime numbers discarding even and odd numbers and skips 6 iterations at a time until radical I