### PR TITLE
Added toUpperTitle method that accepts a string and removes all non alphanumeric characters and capitalizes each letter of every first word

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,22 @@
 # Changes
 
+## Version 1.0.5
+
+### Added
+
+- Added toUpperTitle method that accepts a string and removes all non alphanumeric characters and capitalizes each letter of every first word
+
+```typescript
+import {Formatter} from '@mhmdhammoud/meritt-utils'
+
+// Usage Example
+const sentence:string = "hello__world$$99"
+console.log(Formatter.toUpperTitle(sentence))
+
+console : Hello World 99
+
+```
+
 ## Version 1.0.4
 
 ### Added
@@ -41,9 +58,7 @@ const slug = Formatter.slugify('My Product Name') // my-product-name
 ### Fixes and Improvements
 
 - Fixed bug in Crypto class where encrypting a string with a key that is not a number would throw an error
-
 - Improved Crypto class to allow encrypting and decrypting numbers and objects
-
 - Documented Crypto class
 
 ## Version 1.0.2

--- a/dist/lib/formatter.d.ts
+++ b/dist/lib/formatter.d.ts
@@ -29,6 +29,18 @@ declare class Formatter {
      * */
     obfuscate: (email: string) => string;
     /**
+     * Capitalizes the first letter of each word in a sentence and removes non-alphanumeric characters.
+     * @param sentence - The input sentence to be processed.
+     * @returns A new sentence with the first letter of each word capitalized and non-alphanumeric characters removed.
+     * @example
+     * ```typescript
+     * const sentence = 'this is34354345a---sentence'
+     * const newSentence = ToUpperTitle(sentence)
+     * console.log(newSentence) // 'This Is A Sentence'
+     * ```
+     */
+    toUpperTitle: (sentence: string) => string;
+    /**
      * @remarks Generates a slug from a given string
      * @param title - string to be converted to slug
      * @returns slug

--- a/dist/lib/formatter.js
+++ b/dist/lib/formatter.js
@@ -79,6 +79,32 @@ class Formatter {
                 email.slice(separatorIndex));
         };
         /**
+         * Capitalizes the first letter of each word in a sentence and removes non-alphanumeric characters.
+         * @param sentence - The input sentence to be processed.
+         * @returns A new sentence with the first letter of each word capitalized and non-alphanumeric characters removed.
+         * @example
+         * ```typescript
+         * const sentence = 'this is34354345a---sentence'
+         * const newSentence = ToUpperTitle(sentence)
+         * console.log(newSentence) // 'This Is A Sentence'
+         * ```
+         */
+        this.toUpperTitle = (sentence) => {
+            if (typeof sentence !== 'string')
+                throw new Error('Provide a valid string');
+            if (!sentence)
+                throw new Error('Provide a valid string');
+            const sanitizedSentence = sentence.replace(/[^a-zA-Z0-9]+/g, ' ');
+            const words = sanitizedSentence.split(' ');
+            const capitalizedWords = [];
+            for (let i = 0; i < words.length; i++) {
+                const word = words[i];
+                const capitalizedWord = word.charAt(0).toUpperCase() + word.slice(1);
+                capitalizedWords.push(capitalizedWord);
+            }
+            return capitalizedWords.join(' ');
+        };
+        /**
          * @remarks Generates a slug from a given string
          * @param title - string to be converted to slug
          * @returns slug

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
 	"name": "@mhmdhammoud/meritt-utils",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mhmdhammoud/meritt-utils",
-			"version": "1.0.4",
+			"version": "1.0.5",
 			"license": "ISC",
-			"dependencies": {
-				"dotenv": "^10.0.0"
-			},
 			"devDependencies": {
 				"@types/jest": "^27.5.1",
 				"@typescript-eslint/eslint-plugin": "^5.17.0",
@@ -662,13 +659,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/dotenv": {
-			"version": "10.0.0",
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/dynamic-dedupe": {
@@ -2328,9 +2318,6 @@
 			"requires": {
 				"esutils": "^2.0.2"
 			}
-		},
-		"dotenv": {
-			"version": "10.0.0"
 		},
 		"dynamic-dedupe": {
 			"version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mhmdhammoud/meritt-utils",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "",
 	"main": "./dist/index.js",
 	"private": false,
@@ -20,9 +20,6 @@
 		"prepare": "husky install",
 		"lint": "eslint src --fix",
 		"prepublish": "npm run build"
-	},
-	"dependencies": {
-		"dotenv": "^10.0.0"
 	},
 	"devDependencies": {
 		"ts-node-dev": "^1.1.8",

--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -16,7 +16,7 @@ class Formatter {
 	 * // => 'Hello-World'
 	 * ```
 	 * */
-	toUpperFirst = (_: string | number, withSpacing = true) => {
+	toUpperFirst = (_: string | number, withSpacing = true): string => {
 		if (typeof _ !== 'string') throw new Error('Provide a valid string')
 		if (withSpacing) {
 			return _.split(' ')
@@ -77,6 +77,34 @@ class Formatter {
 			email.slice(2, separatorIndex).replace(/./g, '*') +
 			email.slice(separatorIndex)
 		)
+	}
+
+	/**
+	 * Capitalizes the first letter of each word in a sentence and removes non-alphanumeric characters.
+	 * @param sentence - The input sentence to be processed.
+	 * @returns A new sentence with the first letter of each word capitalized and non-alphanumeric characters removed.
+	 * @example
+	 * ```typescript
+	 * const sentence = 'this is34354345a---sentence'
+	 * const newSentence = ToUpperTitle(sentence)
+	 * console.log(newSentence) // 'This Is A Sentence'
+	 * ```
+	 */
+	toUpperTitle = (sentence: string): string => {
+		if (typeof sentence !== 'string') throw new Error('Provide a valid string')
+		if (!sentence) throw new Error('Provide a valid string')
+
+		const sanitizedSentence = sentence.replace(/[^a-zA-Z0-9]+/g, ' ')
+		const words = sanitizedSentence.split(' ')
+		const capitalizedWords = []
+
+		for (let i = 0; i < words.length; i++) {
+			const word = words[i]
+			const capitalizedWord = word.charAt(0).toUpperCase() + word.slice(1)
+			capitalizedWords.push(capitalizedWord)
+		}
+
+		return capitalizedWords.join(' ')
 	}
 
 	/**


### PR DESCRIPTION
## Version 1.0.5

### Added

- Added toUpperTitle method that accepts a string and removes all non alphanumeric characters and capitalizes each letter of every first word

```typescript
import {Formatter} from '@mhmdhammoud/meritt-utils'

// Usage Example
const sentence:string = "hello__world$$99"
console.log(Formatter.toUpperTitle(sentence))

console : Hello World 99

```