### PR TITLE
build(deps): downgrade @elastic/elasticsearch to v8 and bump to v1.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "@mhmdhammoud/meritt-utils",
-	"version": "1.5.3",
+	"version": "1.5.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mhmdhammoud/meritt-utils",
-			"version": "1.5.3",
+			"version": "1.5.4",
 			"license": "ISC",
 			"dependencies": {
-				"@elastic/elasticsearch": "^9.3.2",
+				"@elastic/elasticsearch": "^8.17.0",
 				"axios": "^1.4.0",
 				"dotenv": "^16.4.1",
 				"imagesloaded": "^5.0.0",
@@ -591,12 +591,12 @@
 			}
 		},
 		"node_modules/@elastic/elasticsearch": {
-			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-9.3.2.tgz",
-			"integrity": "sha512-Td9+dajSx5KebnNgsxDxTDWSDL4bUILPiUGAFKiaCWRI0uSgmfOGrlFA8IUZDurjPpSy06o5cIBrVcPs37zHaQ==",
+			"version": "8.19.1",
+			"resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.19.1.tgz",
+			"integrity": "sha512-+1j9NnQVOX+lbWB8LhCM7IkUmjU05Y4+BmSLfusq0msCsQb1Va+OUKFCoOXjCJqQrcgdRdQCjYYyolQ/npQALQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@elastic/transport": "^9.3.3",
+				"@elastic/transport": "^8.9.6",
 				"apache-arrow": "18.x - 21.x",
 				"tslib": "^2.4.0"
 			},
@@ -604,15 +604,10 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@elastic/elasticsearch/node_modules/tslib": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-		},
 		"node_modules/@elastic/transport": {
-			"version": "9.3.3",
-			"resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-9.3.3.tgz",
-			"integrity": "sha512-0QeEKScXdpwE8pCU/F4aDv5OO7rgh/WNmVScDhrfHS6vNLjRa0/403hzcvmyqt2ULhfDuN6hNLgnI6mtvKuO/Q==",
+			"version": "8.10.1",
+			"resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.10.1.tgz",
+			"integrity": "sha512-xo2lPBAJEt81fQRAKa9T/gUq1SPGBHpSnVUXhoSpL996fPZRAfQwFA4BZtEUQL1p8Dezodd3ZN8Wwno+mYyKuw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "1.x",
@@ -620,18 +615,18 @@
 				"debug": "^4.4.1",
 				"hpagent": "^1.2.0",
 				"ms": "^2.1.3",
-				"secure-json-parse": "^4.0.0",
+				"secure-json-parse": "^3.0.1",
 				"tslib": "^2.8.1",
-				"undici": "^7.19.1"
+				"undici": "^6.21.1"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@elastic/transport/node_modules/secure-json-parse": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
-			"integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-3.0.2.tgz",
+			"integrity": "sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==",
 			"funding": [
 				{
 					"type": "github",
@@ -643,12 +638,6 @@
 				}
 			],
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/@elastic/transport/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD"
 		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.9.1",
@@ -1370,12 +1359,6 @@
 				"tslib": "^2.8.0"
 			}
 		},
-		"node_modules/@swc/helpers/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD"
-		},
 		"node_modules/@tsconfig/node10": {
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -1905,12 +1888,6 @@
 			"bin": {
 				"arrow2csv": "bin/arrow2csv.js"
 			}
-		},
-		"node_modules/apache-arrow/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD"
 		},
 		"node_modules/arg": {
 			"version": "4.1.3",
@@ -5063,70 +5040,6 @@
 				"pino-elasticsearch": "cli.js"
 			}
 		},
-		"node_modules/pino-elasticsearch/node_modules/@elastic/elasticsearch": {
-			"version": "8.19.1",
-			"resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.19.1.tgz",
-			"integrity": "sha512-+1j9NnQVOX+lbWB8LhCM7IkUmjU05Y4+BmSLfusq0msCsQb1Va+OUKFCoOXjCJqQrcgdRdQCjYYyolQ/npQALQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@elastic/transport": "^8.9.6",
-				"apache-arrow": "18.x - 21.x",
-				"tslib": "^2.4.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/pino-elasticsearch/node_modules/@elastic/transport": {
-			"version": "8.10.1",
-			"resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.10.1.tgz",
-			"integrity": "sha512-xo2lPBAJEt81fQRAKa9T/gUq1SPGBHpSnVUXhoSpL996fPZRAfQwFA4BZtEUQL1p8Dezodd3ZN8Wwno+mYyKuw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@opentelemetry/api": "1.x",
-				"@opentelemetry/core": "2.x",
-				"debug": "^4.4.1",
-				"hpagent": "^1.2.0",
-				"ms": "^2.1.3",
-				"secure-json-parse": "^3.0.1",
-				"tslib": "^2.8.1",
-				"undici": "^6.21.1"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/pino-elasticsearch/node_modules/secure-json-parse": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-3.0.2.tgz",
-			"integrity": "sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/pino-elasticsearch/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD"
-		},
-		"node_modules/pino-elasticsearch/node_modules/undici": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-			"integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.17"
-			}
-		},
 		"node_modules/pino-pretty": {
 			"version": "10.3.1",
 			"resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
@@ -6016,6 +5929,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"dev": true,
@@ -6305,12 +6224,12 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.22.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-			"integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+			"integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.18.1"
+				"node": ">=18.17"
 			}
 		},
 		"node_modules/undici-types": {
@@ -6934,46 +6853,34 @@
 			}
 		},
 		"@elastic/elasticsearch": {
-			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-9.3.2.tgz",
-			"integrity": "sha512-Td9+dajSx5KebnNgsxDxTDWSDL4bUILPiUGAFKiaCWRI0uSgmfOGrlFA8IUZDurjPpSy06o5cIBrVcPs37zHaQ==",
+			"version": "8.19.1",
+			"resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.19.1.tgz",
+			"integrity": "sha512-+1j9NnQVOX+lbWB8LhCM7IkUmjU05Y4+BmSLfusq0msCsQb1Va+OUKFCoOXjCJqQrcgdRdQCjYYyolQ/npQALQ==",
 			"requires": {
-				"@elastic/transport": "^9.3.3",
+				"@elastic/transport": "^8.9.6",
 				"apache-arrow": "18.x - 21.x",
 				"tslib": "^2.4.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.6.2",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-					"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-				}
 			}
 		},
 		"@elastic/transport": {
-			"version": "9.3.3",
-			"resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-9.3.3.tgz",
-			"integrity": "sha512-0QeEKScXdpwE8pCU/F4aDv5OO7rgh/WNmVScDhrfHS6vNLjRa0/403hzcvmyqt2ULhfDuN6hNLgnI6mtvKuO/Q==",
+			"version": "8.10.1",
+			"resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.10.1.tgz",
+			"integrity": "sha512-xo2lPBAJEt81fQRAKa9T/gUq1SPGBHpSnVUXhoSpL996fPZRAfQwFA4BZtEUQL1p8Dezodd3ZN8Wwno+mYyKuw==",
 			"requires": {
 				"@opentelemetry/api": "1.x",
 				"@opentelemetry/core": "2.x",
 				"debug": "^4.4.1",
 				"hpagent": "^1.2.0",
 				"ms": "^2.1.3",
-				"secure-json-parse": "^4.0.0",
+				"secure-json-parse": "^3.0.1",
 				"tslib": "^2.8.1",
-				"undici": "^7.19.1"
+				"undici": "^6.21.1"
 			},
 			"dependencies": {
 				"secure-json-parse": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
-					"integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="
-				},
-				"tslib": {
-					"version": "2.8.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-3.0.2.tgz",
+					"integrity": "sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w=="
 				}
 			}
 		},
@@ -7506,13 +7413,6 @@
 			"integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
 			"requires": {
 				"tslib": "^2.8.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.8.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-				}
 			}
 		},
 		"@tsconfig/node10": {
@@ -7886,13 +7786,6 @@
 				"flatbuffers": "^25.1.24",
 				"json-bignum": "^0.0.3",
 				"tslib": "^2.6.2"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.8.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-				}
 			}
 		},
 		"arg": {
@@ -10045,48 +9938,6 @@
 				"minimist": "^1.2.5",
 				"pump": "^3.0.0",
 				"split2": "^4.0.0"
-			},
-			"dependencies": {
-				"@elastic/elasticsearch": {
-					"version": "8.19.1",
-					"resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.19.1.tgz",
-					"integrity": "sha512-+1j9NnQVOX+lbWB8LhCM7IkUmjU05Y4+BmSLfusq0msCsQb1Va+OUKFCoOXjCJqQrcgdRdQCjYYyolQ/npQALQ==",
-					"requires": {
-						"@elastic/transport": "^8.9.6",
-						"apache-arrow": "18.x - 21.x",
-						"tslib": "^2.4.0"
-					}
-				},
-				"@elastic/transport": {
-					"version": "8.10.1",
-					"resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.10.1.tgz",
-					"integrity": "sha512-xo2lPBAJEt81fQRAKa9T/gUq1SPGBHpSnVUXhoSpL996fPZRAfQwFA4BZtEUQL1p8Dezodd3ZN8Wwno+mYyKuw==",
-					"requires": {
-						"@opentelemetry/api": "1.x",
-						"@opentelemetry/core": "2.x",
-						"debug": "^4.4.1",
-						"hpagent": "^1.2.0",
-						"ms": "^2.1.3",
-						"secure-json-parse": "^3.0.1",
-						"tslib": "^2.8.1",
-						"undici": "^6.21.1"
-					}
-				},
-				"secure-json-parse": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-3.0.2.tgz",
-					"integrity": "sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w=="
-				},
-				"tslib": {
-					"version": "2.8.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-					"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
-				},
-				"undici": {
-					"version": "6.23.0",
-					"resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-					"integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g=="
-				}
 			}
 		},
 		"pino-pretty": {
@@ -10666,6 +10517,11 @@
 				}
 			}
 		},
+		"tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+		},
 		"type-check": {
 			"version": "0.4.0",
 			"dev": true,
@@ -10828,9 +10684,9 @@
 			"integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw=="
 		},
 		"undici": {
-			"version": "7.22.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-			"integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg=="
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+			"integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g=="
 		},
 		"undici-types": {
 			"version": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mhmdhammoud/meritt-utils",
-	"version": "1.5.3",
+	"version": "1.5.4",
 	"description": "",
 	"main": "./dist/index.js",
 	"private": false,
@@ -44,7 +44,7 @@
 	"author": "Mhmdhammoud",
 	"license": "ISC",
 	"dependencies": {
-		"@elastic/elasticsearch": "^9.3.2",
+		"@elastic/elasticsearch": "^8.17.0",
 		"axios": "^1.4.0",
 		"dotenv": "^16.4.1",
 		"imagesloaded": "^5.0.0",


### PR DESCRIPTION
## Summary
- Downgrade `@elastic/elasticsearch` from `^9.3.2` to `^8.17.0` to align with the custom elastic transport implementation
- Bump package version to `1.5.4`
- Consolidate duplicate `tslib` and `undici` entries in the lockfile into single top-level resolutions

## What changed
The custom `elastic-transport.ts` introduced in this branch targets the v8 Elasticsearch client API. Having `^9.3.2` as the direct dependency caused the lockfile to carry two conflicting versions (v8 from `pino-elasticsearch` and v9 from the top-level dep). Pinning to `^8.17.0` eliminates the duplication, shrinks the lockfile significantly (~190 lines removed), and ensures the client version actually used at runtime matches the one the transport was written against.

## Test plan
- [x] Run `npm install` and confirm no peer-dependency warnings
- [ ] Run `npm test` — all existing tests pass
- [ ] Verify `@elastic/elasticsearch` resolves to a single v8.x entry in `node_modules`

## Notes
None — no API surface changes, purely a dependency alignment fix.