### PR TITLE
chore: bump version to 1.5.7 and enhance logger with dynamic field re…

### DIFF
--- a/dist/__tests__/logger.test.js
+++ b/dist/__tests__/logger.test.js
@@ -109,4 +109,28 @@ describe('route and format logs', () => {
             key1: 'val1',
         }));
     });
+    test('remap reserved elastic field names dynamically', () => {
+        //@ts-ignore
+        jest.spyOn(pino_1.pino, 'destination').mockReturnValue(PINO_DESTINATION);
+        //@ts-ignore
+        pino_1.pino.mockReturnValue(PINO);
+        const logger = new logger_1.default(LOGGER_NAME);
+        logger.info(LOG_EVENT, {
+            _id: 'abc123',
+            nested: {
+                _id: 'nested-1',
+                _index: 'bad-index',
+            },
+        });
+        expect(PINO.info).toHaveBeenCalledWith(expect.objectContaining({
+            mongo_id: 'abc123',
+            nested: expect.objectContaining({
+                mongo_id: 'nested-1',
+                es_index: 'bad-index',
+            }),
+        }));
+        expect(PINO.info).not.toHaveBeenCalledWith(expect.objectContaining({
+            _id: expect.anything(),
+        }));
+    });
 });

--- a/dist/lib/logger.js
+++ b/dist/lib/logger.js
@@ -42,12 +42,107 @@ const trace_store_1 = require("./trace-store");
 dotenv.config();
 /** Convert camelCase to snake_case for Kibana/ECS-friendly field names */
 const toSnakeCase = (str) => str.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+/**
+ * Elasticsearch reserves metadata fields (e.g. `_id`) and rejects documents
+ * containing them in payload body. Remap them to safe application fields.
+ */
+const RESERVED_ES_FIELD_ALIASES = {
+    _id: 'mongo_id',
+    _index: 'es_index',
+    _type: 'es_type',
+    _score: 'es_score',
+    _source: 'es_source',
+    _routing: 'es_routing',
+    _seq_no: 'es_seq_no',
+    _primary_term: 'es_primary_term',
+    _version: 'es_version',
+};
+/** Convert arbitrary field names into ES-safe flattened keys */
+const toSafeElasticFieldName = (key) => {
+    const normalized = toSnakeCase(key);
+    const mapped = RESERVED_ES_FIELD_ALIASES[normalized];
+    if (mapped) {
+        return mapped;
+    }
+    // Any leading underscore can conflict with ES internals, remap defensively.
+    return normalized.startsWith('_') ? `meta${normalized}` : normalized;
+};
+const isObjectIdLike = (v) => v !== null &&
+    typeof v === 'object' &&
+    'toHexString' in v &&
+    typeof v.toHexString === 'function';
 /** Check if value is a plain object (not Error, Date, Array, null) */
 const isPlainObject = (v) => v !== null &&
     typeof v === 'object' &&
     !Array.isArray(v) &&
     !(v instanceof Error) &&
     !(v instanceof Date);
+/**
+ * Recursively sanitize log values for Elasticsearch safety.
+ * - Remaps reserved key names (e.g. `_id` -> `mongo_id`)
+ * - Converts Error to a stable serializable shape
+ * - Converts ObjectId-like objects to hex strings
+ * - Prevents circular structure failures
+ */
+const sanitizeForElastic = (value, seen = new WeakSet()) => {
+    if (value === null ||
+        typeof value === 'string' ||
+        typeof value === 'number' ||
+        typeof value === 'boolean') {
+        return value;
+    }
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+    if (value instanceof Error) {
+        return { message: value.message, type: value.constructor.name };
+    }
+    if (isObjectIdLike(value)) {
+        return value.toHexString();
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => sanitizeForElastic(item, seen));
+    }
+    if (isPlainObject(value)) {
+        if (seen.has(value)) {
+            return '[Circular]';
+        }
+        seen.add(value);
+        const sanitizedObject = {};
+        for (const [k, v] of Object.entries(value)) {
+            sanitizedObject[toSafeElasticFieldName(k)] = sanitizeForElastic(v, seen);
+        }
+        return sanitizedObject;
+    }
+    // Fallback for class instances and non-plain objects.
+    return String(value);
+};
+/**
+ * Captures the call site from the stack when log event is missing.
+ * Returns file:line (e.g. product.service.ts:2266) for Kibana/Elasticsearch filtering.
+ */
+const getCallSiteForMissingLog = () => {
+    var _a;
+    try {
+        const stack = (_a = new Error().stack) !== null && _a !== void 0 ? _a : '';
+        const lines = stack.split('\n');
+        // First frame outside Logger / node_modules / meritt-utils
+        const appFrame = lines.find((line) => !line.includes('node_modules') &&
+            !line.includes('meritt-utils') &&
+            !line.includes('Logger.'));
+        if (!appFrame)
+            return undefined;
+        // Extract file:line e.g. "product.service.ts:2266"
+        const match = appFrame.match(/([^/\\]+\.(?:ts|js|tsx|jsx)):(\d+)/);
+        if (match) {
+            return `${match[1]}:${match[2]}`;
+        }
+        return appFrame.trim().slice(0, 100);
+    }
+    catch (_b) {
+        return undefined;
+    }
+};
 /**
  * Pino logger backend - singleton
  */
@@ -210,7 +305,9 @@ function getLogger(elasticConfig) {
                 console.error('[Logger] Some logs failed to index to Elasticsearch.');
                 if (err.document) {
                     const docStr = JSON.stringify(err.document);
-                    const preview = docStr.length > 500 ? `${docStr.substring(0, 500)}... (truncated)` : docStr;
+                    const preview = docStr.length > 500
+                        ? `${docStr.substring(0, 500)}... (truncated)`
+                        : docStr;
                     console.error('[Logger] Dropped document preview:', preview);
                 }
             });
@@ -265,9 +362,10 @@ class Logger {
         var _a, _b;
         const isLocal = process.env.NODE_ENV === 'local' || process.env.NODE_ENV === 'test';
         // Defensive: missing Logs constant (undefined) crashes on logEvent.code
-        const event = logEvent && typeof logEvent === 'object' && 'code' in logEvent
-            ? logEvent
-            : { code: 'UNKNOWN', msg: 'Missing or invalid log event constant' };
+        const useFallback = !logEvent || typeof logEvent !== 'object' || !('code' in logEvent);
+        const event = useFallback
+            ? { code: 'UNKNOWN', msg: 'Missing or invalid log event constant' }
+            : logEvent;
         // ECS-aligned fields for Kibana (flat names to avoid mapping conflicts with existing indices)
         const ecs = {
             log_level: logLevel,
@@ -291,11 +389,8 @@ class Logger {
             Object.keys(args[0]).length > 0) {
             const obj = args[0];
             for (const [k, v] of Object.entries(obj)) {
-                const key = toSnakeCase(k);
-                ecs[key] =
-                    v instanceof Error
-                        ? { message: v.message, type: v.constructor.name }
-                        : v;
+                const key = toSafeElasticFieldName(k);
+                ecs[key] = sanitizeForElastic(v);
             }
         }
         else {
@@ -310,6 +405,13 @@ class Logger {
         };
         if (detail !== undefined) {
             base.detail = detail;
+        }
+        // When fallback used: add call site for Kibana/Elasticsearch querying
+        if (useFallback) {
+            const callSite = getCallSiteForMissingLog();
+            if (callSite) {
+                base.missing_log_call_site = callSite;
+            }
         }
         return base;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@mhmdhammoud/meritt-utils",
-	"version": "1.5.5",
+	"version": "1.5.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@mhmdhammoud/meritt-utils",
-			"version": "1.5.5",
+			"version": "1.5.7",
 			"license": "ISC",
 			"dependencies": {
 				"@elastic/elasticsearch": "^8.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mhmdhammoud/meritt-utils",
-	"version": "1.5.6",
+	"version": "1.5.7",
 	"description": "",
 	"main": "./dist/index.js",
 	"private": false,

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -89,4 +89,35 @@ describe('route and format logs', () => {
 			})
 		)
 	})
+
+	test('remap reserved elastic field names dynamically', () => {
+		//@ts-ignore
+		jest.spyOn(pino, 'destination').mockReturnValue(PINO_DESTINATION)
+		//@ts-ignore
+		pino.mockReturnValue(PINO)
+		const logger = new Logger(LOGGER_NAME)
+
+		logger.info(LOG_EVENT, {
+			_id: 'abc123',
+			nested: {
+				_id: 'nested-1',
+				_index: 'bad-index',
+			},
+		})
+
+		expect(PINO.info).toHaveBeenCalledWith(
+			expect.objectContaining({
+				mongo_id: 'abc123',
+				nested: expect.objectContaining({
+					mongo_id: 'nested-1',
+					es_index: 'bad-index',
+				}),
+			})
+		)
+		expect(PINO.info).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				_id: expect.anything(),
+			})
+		)
+	})
 })

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -11,6 +11,39 @@ dotenv.config()
 const toSnakeCase = (str: string): string =>
 	str.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`)
 
+/**
+ * Elasticsearch reserves metadata fields (e.g. `_id`) and rejects documents
+ * containing them in payload body. Remap them to safe application fields.
+ */
+const RESERVED_ES_FIELD_ALIASES: Record<string, string> = {
+	_id: 'mongo_id',
+	_index: 'es_index',
+	_type: 'es_type',
+	_score: 'es_score',
+	_source: 'es_source',
+	_routing: 'es_routing',
+	_seq_no: 'es_seq_no',
+	_primary_term: 'es_primary_term',
+	_version: 'es_version',
+}
+
+/** Convert arbitrary field names into ES-safe flattened keys */
+const toSafeElasticFieldName = (key: string): string => {
+	const normalized = toSnakeCase(key)
+	const mapped = RESERVED_ES_FIELD_ALIASES[normalized]
+	if (mapped) {
+		return mapped
+	}
+	// Any leading underscore can conflict with ES internals, remap defensively.
+	return normalized.startsWith('_') ? `meta${normalized}` : normalized
+}
+
+const isObjectIdLike = (v: unknown): v is { toHexString: () => string } =>
+	v !== null &&
+	typeof v === 'object' &&
+	'toHexString' in v &&
+	typeof (v as { toHexString?: unknown }).toHexString === 'function'
+
 /** Check if value is a plain object (not Error, Date, Array, null) */
 const isPlainObject = (v: unknown): v is Record<string, unknown> =>
 	v !== null &&
@@ -18,6 +51,86 @@ const isPlainObject = (v: unknown): v is Record<string, unknown> =>
 	!Array.isArray(v) &&
 	!(v instanceof Error) &&
 	!(v instanceof Date)
+
+/**
+ * Recursively sanitize log values for Elasticsearch safety.
+ * - Remaps reserved key names (e.g. `_id` -> `mongo_id`)
+ * - Converts Error to a stable serializable shape
+ * - Converts ObjectId-like objects to hex strings
+ * - Prevents circular structure failures
+ */
+const sanitizeForElastic = (
+	value: unknown,
+	seen: WeakSet<object> = new WeakSet<object>()
+): unknown => {
+	if (
+		value === null ||
+		typeof value === 'string' ||
+		typeof value === 'number' ||
+		typeof value === 'boolean'
+	) {
+		return value
+	}
+
+	if (value instanceof Date) {
+		return value.toISOString()
+	}
+
+	if (value instanceof Error) {
+		return { message: value.message, type: value.constructor.name }
+	}
+
+	if (isObjectIdLike(value)) {
+		return value.toHexString()
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item) => sanitizeForElastic(item, seen))
+	}
+
+	if (isPlainObject(value)) {
+		if (seen.has(value)) {
+			return '[Circular]'
+		}
+		seen.add(value)
+
+		const sanitizedObject: Record<string, unknown> = {}
+		for (const [k, v] of Object.entries(value)) {
+			sanitizedObject[toSafeElasticFieldName(k)] = sanitizeForElastic(v, seen)
+		}
+		return sanitizedObject
+	}
+
+	// Fallback for class instances and non-plain objects.
+	return String(value)
+}
+
+/**
+ * Captures the call site from the stack when log event is missing.
+ * Returns file:line (e.g. product.service.ts:2266) for Kibana/Elasticsearch filtering.
+ */
+const getCallSiteForMissingLog = (): string | undefined => {
+	try {
+		const stack = new Error().stack ?? ''
+		const lines = stack.split('\n')
+		// First frame outside Logger / node_modules / meritt-utils
+		const appFrame = lines.find(
+			(line) =>
+				!line.includes('node_modules') &&
+				!line.includes('meritt-utils') &&
+				!line.includes('Logger.')
+		)
+		if (!appFrame) return undefined
+		// Extract file:line e.g. "product.service.ts:2266"
+		const match = appFrame.match(/([^/\\]+\.(?:ts|js|tsx|jsx)):(\d+)/)
+		if (match) {
+			return `${match[1]}:${match[2]}`
+		}
+		return appFrame.trim().slice(0, 100)
+	} catch {
+		return undefined
+	}
+}
 
 /**
  * Pino logger backend - singleton
@@ -325,10 +438,11 @@ class Logger {
 			process.env.NODE_ENV === 'local' || process.env.NODE_ENV === 'test'
 
 		// Defensive: missing Logs constant (undefined) crashes on logEvent.code
-		const event =
-			logEvent && typeof logEvent === 'object' && 'code' in logEvent
-				? logEvent
-				: { code: 'UNKNOWN', msg: 'Missing or invalid log event constant' }
+		const useFallback =
+			!logEvent || typeof logEvent !== 'object' || !('code' in logEvent)
+		const event = useFallback
+			? { code: 'UNKNOWN', msg: 'Missing or invalid log event constant' }
+			: logEvent
 
 		// ECS-aligned fields for Kibana (flat names to avoid mapping conflicts with existing indices)
 		const ecs: Record<string, unknown> = {
@@ -357,11 +471,8 @@ class Logger {
 		) {
 			const obj = args[0]
 			for (const [k, v] of Object.entries(obj)) {
-				const key = toSnakeCase(k)
-				ecs[key] =
-					v instanceof Error
-						? { message: v.message, type: v.constructor.name }
-						: v
+				const key = toSafeElasticFieldName(k)
+				ecs[key] = sanitizeForElastic(v)
 			}
 		} else {
 			detail = isLocal ? args : JSON.stringify(args)
@@ -376,6 +487,13 @@ class Logger {
 		}
 		if (detail !== undefined) {
 			base.detail = detail
+		}
+		// When fallback used: add call site for Kibana/Elasticsearch querying
+		if (useFallback) {
+			const callSite = getCallSiteForMissingLog()
+			if (callSite) {
+				base.missing_log_call_site = callSite
+			}
 		}
 		return base
 	}


### PR DESCRIPTION
…mapping for Elasticsearch

- Updated version in package.json and package-lock.json to 1.5.7.
- Implemented dynamic remapping of reserved Elasticsearch field names to safe application fields in the logger.
- Added sanitization for log values to ensure compatibility with Elasticsearch, preventing issues with reserved metadata fields.
- Enhanced test coverage for the new field remapping functionality.