### PR TITLE
test: update logger test to reflect changes in field remapping and sc…

### DIFF
--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -90,7 +90,7 @@ describe('route and format logs', () => {
 		)
 	})
 
-	test('remap reserved elastic field names dynamically', () => {
+	test('remap reserved elastic field names and reduce objects to scalars', () => {
 		//@ts-ignore
 		jest.spyOn(pino, 'destination').mockReturnValue(PINO_DESTINATION)
 		//@ts-ignore
@@ -105,13 +105,11 @@ describe('route and format logs', () => {
 			},
 		})
 
+		// Top-level fields use scalars only (avoids ES document_parsing_exception)
 		expect(PINO.info).toHaveBeenCalledWith(
 			expect.objectContaining({
 				mongo_id: 'abc123',
-				nested: expect.objectContaining({
-					mongo_id: 'nested-1',
-					es_index: 'bad-index',
-				}),
+				nested: 'nested-1',
 			})
 		)
 		expect(PINO.info).not.toHaveBeenCalledWith(


### PR DESCRIPTION
…alar reduction

- Renamed test to clarify its purpose regarding both remapping reserved Elasticsearch field names and reducing objects to scalars.
- Adjusted test expectations to ensure top-level fields use scalars, preventing Elasticsearch document parsing exceptions.